### PR TITLE
GitHub actions timezone

### DIFF
--- a/.github/workflows/github-actions-timezone.yml
+++ b/.github/workflows/github-actions-timezone.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - github-actions-timezone
 
+env:
+  TZ: 'Asia/Tokyo'
+
 jobs:
   run:
     name: run

--- a/.github/workflows/github-actions-timezone.yml
+++ b/.github/workflows/github-actions-timezone.yml
@@ -1,0 +1,19 @@
+name: GitHub Actions Timezone
+
+on:
+  push:
+    branches:
+      - github-actions-timezone
+
+jobs:
+  run:
+    name: run
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: print Timezone
+        run: echo `date`
+      - name: print Timezone with TZ env
+        env:
+          TZ: "Asia/Tokyo"
+        run: echo `date`


### PR DESCRIPTION
* default timezone is UTC & set env TZ  on step

https://github.com/nipe0324/github-actions-test/pull/1/commits/999e0c53d4fd1bcd65d94cc99eac859beede1661

<img width="373" alt="スクリーンショット 2022-07-08 12 14 35" src="https://user-images.githubusercontent.com/2967009/177909972-ca59f317-7c8e-4f24-868d-4c4a971f340a.png">


* timezone with all steps (set global env)

https://github.com/nipe0324/github-actions-test/pull/1/commits/510615897a096b4f38f1cb0e755f174ebb1b6d3c

<img width="432" alt="スクリーンショット 2022-07-08 12 16 11" src="https://user-images.githubusercontent.com/2967009/177910140-b43cdd9b-245d-46af-856c-1bb7d464cdcf.png">
